### PR TITLE
Add link to Django sample app, update requirements

### DIFF
--- a/example/example.py
+++ b/example/example.py
@@ -3,6 +3,11 @@ from devcycle_python_sdk import Configuration, DVCClient, DVCOptions, UserData, 
 from devcycle_python_sdk.rest import ApiException
 
 def main():
+    """
+    Sample generic usage of the Python SDK.
+    For a Django specific sample app, please see https://github.com/DevCycleHQ/python-django-example-app/
+
+    """
     configuration = Configuration()
     configuration.api_key['Authorization'] = '<DVC_SERVER_SDK_KEY>'
     options = DVCOptions(enableEdgeDB=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ six >= 1.10
 python_dateutil >= 2.5.3
 setuptools >= 21.0.0
 urllib3 >= 1.15.1
-devcycle-sdk >= 0.0.0-alpha5


### PR DESCRIPTION
There existed an accidental include of `devcycle-sdk >= 0.0.0-alpha5` (which is the old name of this SDK), likely the result of automatic generation of requirements.txt as a result of pip freeze, or similar. Removing this deprecated cyclical reference to itself.