### PR TITLE
DVC 8077: Small fixes and perf improvements

### DIFF
--- a/devcycle_python_sdk/managers/config_manager.py
+++ b/devcycle_python_sdk/managers/config_manager.py
@@ -84,9 +84,10 @@ class EnvironmentConfigManager(threading.Thread):
             try:
                 self._get_config()
             except Exception as e:
-                logger.info(f"Error polling for config changes: {str(e)}")
+                if self._polling_enabled:
+                    # Only log a warning if we're still polling
+                    logger.warning(f"Error polling for config changes: {str(e)}")
             time.sleep(self._options.config_polling_interval_ms / 1000.0)
 
     def close(self):
         self._polling_enabled = False
-        self.join(timeout=1)

--- a/devcycle_python_sdk/managers/event_queue_manager.py
+++ b/devcycle_python_sdk/managers/event_queue_manager.py
@@ -109,7 +109,7 @@ class EventQueueManager(threading.Thread):
             try:
                 self._event_api_client.publish_events(payload.records)
                 self._local_bucketing.on_event_payload_success(payload.payloadId)
-            except (APIClientUnauthorizedError, NotFoundError):
+            except APIClientUnauthorizedError:
                 logger.error(
                     "Unauthorized to publish events, please check your SDK key"
                 )

--- a/test/managers/test_config_manager.py
+++ b/test/managers/test_config_manager.py
@@ -102,7 +102,6 @@ class EnvironmentConfigManagerTest(unittest.TestCase):
 
         config_manager.close()
         self.assertFalse(config_manager._polling_enabled)
-        self.assertFalse(config_manager.is_alive())
 
     @patch("devcycle_python_sdk.api.config_client.ConfigAPIClient.get_config")
     def test_get_config_unchanged(self, mock_get_config):

--- a/test/managers/test_event_queue_manager.py
+++ b/test/managers/test_event_queue_manager.py
@@ -86,7 +86,7 @@ class EventQueueManagerTest(unittest.TestCase):
         manager = EventQueueManager(
             self.sdk_key, self.test_options, self.test_local_bucketing
         )
-        self.assertTrue(manager._processing_enabled)
+        self.assertTrue(manager._should_run())
         self.assertTrue(manager.is_alive())
         self.assertTrue(manager.daemon)
 
@@ -100,7 +100,7 @@ class EventQueueManagerTest(unittest.TestCase):
         manager.close()
         # let the thread wake up from sleep and react to the close
         time.sleep(0.5)
-        self.assertFalse(manager._processing_enabled)
+        self.assertFalse(manager._should_run())
         self.assertFalse(manager.is_alive())
 
     @patch("devcycle_python_sdk.api.event_client.EventAPIClient.publish_events")

--- a/test/test_dvc_local_client.py
+++ b/test/test_dvc_local_client.py
@@ -36,7 +36,10 @@ class DVCLocalClientTest(unittest.TestCase):
         )
 
         self.options = DevCycleLocalOptions(
-            config_polling_interval_ms=500, config_cdn_uri="http://localhost/"
+            config_polling_interval_ms=5000,
+            config_cdn_uri="http://localhost/",
+            disable_custom_event_logging=True,
+            disable_automatic_event_logging=True,
         )
         self.test_user = User(user_id="test_user_id")
         self.test_user_empty_id = User(user_id="")
@@ -235,6 +238,14 @@ class DVCLocalClientTest(unittest.TestCase):
                 self.assertDictEqual(result.value, expected, msg="Test key: " + key)
             else:
                 self.assertEqual(result.value, expected, msg="Test key: " + key)
+
+    @responses.activate
+    def test_variable_with_events(self):
+        self.options.disable_automatic_event_logging = False
+        self.options.disable_custom_event_logging = False
+        self.setup_client()
+        user = User(user_id="1234")
+        self.client.variable(user, "string-var", "default_value")
 
     @responses.activate
     def test_all_features(self):


### PR DESCRIPTION
The manager changes here make it so the client `close` method no longer is blocked by the event and config managers sleeping, and can interrupt them instead. This mostly just affects the test harness and unit tests runtime, since nobody calls close in real world usage 😆 

I also copied over an optimization from the Go SDK - pre-compute and reuse the header pointer for passing byte arrays. This works as long as we're locking on access to the WASM instance.