### PR TITLE
Add a variable benchmark

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -3,7 +3,7 @@ name: Benchmark
 on: [ push ]
 
 jobs:
-  build:
+  benchmark:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -27,6 +27,7 @@ jobs:
         with:
           tool: 'pytest'
           output-file-path: benchmarks.json
+          external-data-json-path: benchmarks_baseline.json
           # GitHub API token to make a commit comment
           github-token: ${{ secrets.GITHUB_TOKEN }}
           skip-fetch-gh-pages: true

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -26,11 +26,9 @@ jobs:
         uses: benchmark-action/github-action-benchmark@v1
         with:
           tool: 'pytest'
+          output-file-path: benchmarks.json
           # GitHub API token to make a commit comment
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          gh-pages-branch: main
-          # Enable alert commit comment
-          comment-on-alert: true
+          skip-fetch-gh-pages: true
           # Enable Job Summary for PRs
           summary-always: true
-          output-file-path: benchmarks.json

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           tool: 'pytest'
           output-file-path: benchmarks.json
-          external-data-json-path: benchmarks_baseline.json
+          external-data-json-path: benchmarks.json
           # GitHub API token to make a commit comment
           github-token: ${{ secrets.GITHUB_TOKEN }}
           skip-fetch-gh-pages: true

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -28,5 +28,6 @@ jobs:
             echo "### Benchmark Results" >> $GITHUB_STEP_SUMMARY
             echo "
             Benchmark|Min (uS)|Median (uS)|Mean (uS)|Max (uS)|Iterations
+            ---|---|---|---|---|---
             $(jq -r '.benchmarks[] | [.name,(.stats.min*1000000000 | round / 1000),(.stats.median*1000000000 | round / 1000),(.stats.mean*1000000000 | round / 1000),(.stats.max*1000000000 | round / 1000),.stats.rounds] | join("|")' benchmarks.json)
             " >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,36 @@
+name: Benchmark
+
+on: [ push ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ "3.11" ]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install -r requirements.test.txt
+      - name: Run benchmarks
+        run: |
+          pytest --benchmark-only --benchmark-json=benchmarks.json
+      - name: Store benchmark result
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          tool: 'pytest'
+          # GitHub API token to make a commit comment
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          gh-pages-branch: main
+          # Enable alert commit comment
+          comment-on-alert: true
+          # Enable Job Summary for PRs
+          summary-always: true
+          output-file-path: benchmarks.json

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
       - name: Install dependencies
         run: |
           pip install --upgrade pip
@@ -22,14 +23,10 @@ jobs:
       - name: Run benchmarks
         run: |
           pytest --benchmark-only --benchmark-json=benchmarks.json
-      - name: Store benchmark result
-        uses: benchmark-action/github-action-benchmark@v1
-        with:
-          tool: 'pytest'
-          output-file-path: benchmarks.json
-          external-data-json-path: benchmarks.json
-          # GitHub API token to make a commit comment
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          skip-fetch-gh-pages: true
-          # Enable Job Summary for PRs
-          summary-always: true
+      - name: Print summary
+        run: |
+            echo "### Benchmark Results" >> $GITHUB_STEP_SUMMARY
+            echo "
+            Benchmark|Min (uS)|Median (uS)|Mean (uS)|Max (uS)|Iterations
+            $(jq -r '.benchmarks[] | [.name,(.stats.min*1000000000 | round / 1000),(.stats.median*1000000000 | round / 1000),(.stats.mean*1000000000 | round / 1000),(.stats.max*1000000000 | round / 1000),.stats.rounds] | join("|")' benchmarks.json)
+            " >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
       - name: Install dependencies
         run: |
           pip install --upgrade pip

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -21,4 +21,18 @@ jobs:
           pip install -r requirements.test.txt
       - name: Run unit tests
         run: |
-          python -m unittest --verbose --buffer --locals
+          pytest
+      - name: Run benchmarks
+        run: |
+          pytest --benchmark-only --benchmark-json=benchmarks.json
+      - name: Store benchmark result
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          tool: 'pytest'
+          # GitHub API token to make a commit comment
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          # Enable alert commit comment
+          comment-on-alert: true
+          # Enable Job Summary for PRs
+          summary-always: true
+          output-file-path: benchmarks.json

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -22,17 +22,3 @@ jobs:
       - name: Run unit tests
         run: |
           pytest
-      - name: Run benchmarks
-        run: |
-          pytest --benchmark-only --benchmark-json=benchmarks.json
-      - name: Store benchmark result
-        uses: benchmark-action/github-action-benchmark@v1
-        with:
-          tool: 'pytest'
-          # GitHub API token to make a commit comment
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          # Enable alert commit comment
-          comment-on-alert: true
-          # Enable Job Summary for PRs
-          summary-always: true
-          output-file-path: benchmarks.json

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,7 @@ target/
 
 .idea
 .DS_STORE
+
+# Benchmark output
+.benchmarks
+benchmark.json

--- a/README.md
+++ b/README.md
@@ -89,6 +89,13 @@ To run the unit tests, run:
 pytest
 ```
 
+### Benchmarks
+
+To run the benchmarks, run:
+```bash
+pytest --benchmark-only
+```
+
 ### Protobuf Code Generation
 
 To generate the protobuf source files run the following from the root of the project. Ensure you have `protoc` installed.

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ black --target-version py37 --extend-exclude '_pb2\.pyi?$' .
 
 To run the unit tests, run:
 ```bash
-python -m unittest -v
+pytest
 ```
 
 ### Protobuf Code Generation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.pytest.ini_options]
+minversion = "7.0"
+addopts = "--benchmark-skip --showlocals"

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -3,6 +3,8 @@
 black==23.3.0
 mypy==1.3.0
 mypy-extensions==1.0.0
+pytest==7.4.0
+pytest-benchmark==4.0.0
 responses==0.23.1
 ruff==0.0.267
 types-requests==2.31.0.1

--- a/test/test_dvc_local_client.py
+++ b/test/test_dvc_local_client.py
@@ -350,5 +350,47 @@ class DVCLocalClientTest(unittest.TestCase):
         self.assertEqual(result, {})
 
 
+def _benchmark_variable_call(client: DevCycleLocalClient, user: User, key: str):
+    return client.variable(user, key, "default_value")
+
+
+@responses.activate
+def test_benchmark_variable_call(benchmark):
+    sdk_key = "dvc_server_949e4962-c624-4d20-a1ea-7f2501b2ba79"
+    test_config_json = small_config_json()
+    test_etag = "2f71454e-3279-4ca7-a8e7-802ce97bef43"
+
+    config_url = "http://localhost/config/v1/server/" + sdk_key + ".json"
+
+    responses.add(
+        responses.GET,
+        config_url,
+        headers={"ETag": test_etag},
+        json=test_config_json,
+        status=200,
+    )
+
+    options = DevCycleLocalOptions(
+        config_polling_interval_ms=5000,
+        config_cdn_uri="http://localhost/",
+        disable_custom_event_logging=True,
+        disable_automatic_event_logging=True,
+    )
+    user = User(user_id="test_user_id")
+
+    client = DevCycleLocalClient(sdk_key, options)
+    while not client.is_initialized():
+        time.sleep(0.05)
+
+    # benchmark is a pytest fixture provided by pytest-benchmark that handles timing the provided callable
+    result = benchmark(_benchmark_variable_call, client, user, "string-var")
+
+    assert result is not None
+    assert result.key == "string-var"
+    assert result.isDefaulted is False
+    assert result.value == "variationOn"
+    assert result.type == TypeEnum.STRING
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_dvc_local_client.py
+++ b/test/test_dvc_local_client.py
@@ -243,6 +243,7 @@ class DVCLocalClientTest(unittest.TestCase):
     def test_variable_with_events(self):
         self.options.disable_automatic_event_logging = False
         self.options.disable_custom_event_logging = False
+        self.options.event_flush_interval_ms = 0
         self.setup_client()
         user = User(user_id="1234")
         self.client.variable(user, "string-var", "default_value")


### PR DESCRIPTION
This uses pytest-benchmark to automate timing a benchmark function that calls DevCycleLocalClient.variable.

It also switches over to using pytest as the preferred way of running
the unit tests. The standard unittest tools will still work, they'll
just ignore the benchmark tests as they aren't using the class-based
structure.
