### PR TITLE
fix: enforce replace backslash with forward slash

### DIFF
--- a/devcycle_python_sdk/api/bucketing_client.py
+++ b/devcycle_python_sdk/api/bucketing_client.py
@@ -33,7 +33,7 @@ class BucketingAPIClient:
         self.session.max_redirects = 0
 
     def _url(self, *path_args: str) -> str:
-        return join(self.options.bucketing_api_uri, "v1", *path_args)
+        return join(self.options.bucketing_api_uri, "v1", *path_args).replace("\\", "/")
 
     def request(self, method: str, url: str, **kwargs) -> dict:
         retries_remaining = self.options.request_retries + 1


### PR DESCRIPTION
**Issue:**
URLs get malformed when running `os.path.join` on windows. 

1. Fetching all variables `https://bucketing-api.devcycle.com/v1\variables`
2. Fetching single variable with key `https://bucketing-api.devcycle.com/v1\variables\xxxxxx`

**Solution**
Ensure we replace backslashes with forward slashes when building `self._url`

**Platform**
Python 3.11.4
OS Name:                   Microsoft Windows 10 Home
OS Version:                10.0.19045 N/A Build 19045

I also did not find a `CONTRIBUTING.md`, so let me know if there is anything else I need to add