### PR TITLE
fix: API path formatting on Windows

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -5,10 +5,11 @@ on: [ push ]
 jobs:
   unit_tests:
     name: Unit Tests
-    runs-on: ubuntu-latest
+    runs-on: {matrix.os}
     strategy:
       matrix:
         python-version: [ "3.7", "3.11" ]
+        os: [ubuntu-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -5,7 +5,7 @@ on: [ push ]
 jobs:
   unit_tests:
     name: Unit Tests
-    runs-on: {matrix.os}
+    runs-on: ${{matrix.os}}
     strategy:
       matrix:
         python-version: [ "3.7", "3.11" ]

--- a/devcycle_python_sdk/api/bucketing_client.py
+++ b/devcycle_python_sdk/api/bucketing_client.py
@@ -1,6 +1,5 @@
 import logging
 import time
-from os.path import join
 from typing import Dict, List, Optional
 
 import requests
@@ -16,6 +15,7 @@ from devcycle_python_sdk.models.event import DevCycleEvent
 from devcycle_python_sdk.models.feature import Feature
 from devcycle_python_sdk.models.user import DevCycleUser
 from devcycle_python_sdk.models.variable import Variable
+from devcycle_python_sdk.util.strings import slash_join
 
 logger = logging.getLogger(__name__)
 
@@ -33,7 +33,7 @@ class BucketingAPIClient:
         self.session.max_redirects = 0
 
     def _url(self, *path_args: str) -> str:
-        return join(self.options.bucketing_api_uri, "v1", *path_args)
+        return slash_join(self.options.bucketing_api_uri, "v1", *path_args)
 
     def request(self, method: str, url: str, **kwargs) -> dict:
         retries_remaining = self.options.request_retries + 1

--- a/devcycle_python_sdk/api/config_client.py
+++ b/devcycle_python_sdk/api/config_client.py
@@ -1,7 +1,6 @@
 import logging
 import time
 from http import HTTPStatus
-from os.path import join
 from typing import Optional, Tuple
 
 import requests
@@ -13,6 +12,7 @@ from devcycle_python_sdk.exceptions import (
     NotFoundError,
     APIClientUnauthorizedError,
 )
+from devcycle_python_sdk.util.strings import slash_join
 
 logger = logging.getLogger(__name__)
 
@@ -29,7 +29,7 @@ class ConfigAPIClient:
         self.session.max_redirects = 0
         self.max_config_retries = 2
         self.config_file_url = (
-            join(self.options.config_cdn_uri, "config", "v1", "server", self.sdk_key)
+            slash_join(self.options.config_cdn_uri, "config", "v1", "server", self.sdk_key)
             + ".json"
         )
 

--- a/devcycle_python_sdk/api/config_client.py
+++ b/devcycle_python_sdk/api/config_client.py
@@ -29,7 +29,9 @@ class ConfigAPIClient:
         self.session.max_redirects = 0
         self.max_config_retries = 2
         self.config_file_url = (
-            slash_join(self.options.config_cdn_uri, "config", "v1", "server", self.sdk_key)
+            slash_join(
+                self.options.config_cdn_uri, "config", "v1", "server", self.sdk_key
+            )
             + ".json"
         )
 

--- a/devcycle_python_sdk/api/event_client.py
+++ b/devcycle_python_sdk/api/event_client.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import time
-from os.path import join
 from typing import Optional, List
 
 import requests
@@ -14,6 +13,7 @@ from devcycle_python_sdk.exceptions import (
     APIClientUnauthorizedError,
 )
 from devcycle_python_sdk.models.event import UserEventsBatchRecord
+from devcycle_python_sdk.util.strings import slash_join
 
 logger = logging.getLogger(__name__)
 
@@ -29,7 +29,7 @@ class EventAPIClient:
         }
         self.session.max_redirects = 0
         self.max_batch_retries = 0  # we don't retry events batches
-        self.batch_url = join(self.options.events_api_uri, "v1/events/batch")
+        self.batch_url = slash_join(self.options.events_api_uri, "v1/events/batch")
 
     def publish_events(self, batch: List[UserEventsBatchRecord]) -> str:
         """

--- a/devcycle_python_sdk/util/strings.py
+++ b/devcycle_python_sdk/util/strings.py
@@ -1,0 +1,7 @@
+
+def slash_join(*args) -> str:
+    """
+    Assembles a string, concatenating the arguments with a single slash between them
+    removing any leading or trailing slashes from the arguments
+    """
+    return "/".join(str(arg).strip("/") for arg in args)

--- a/devcycle_python_sdk/util/strings.py
+++ b/devcycle_python_sdk/util/strings.py
@@ -1,4 +1,3 @@
-
 def slash_join(*args) -> str:
     """
     Assembles a string, concatenating the arguments with a single slash between them

--- a/test/api/test_bucketing_client.py
+++ b/test/api/test_bucketing_client.py
@@ -228,7 +228,7 @@ class BucketingClientTest(unittest.TestCase):
         )
         self.assertEqual(result, "success")
         data = json.loads(responses.calls[0].request.body)
-        self.assertTrue(type(data["events"][0]["date"]) == int)
+        self.assertTrue(isinstance(data["events"][0]["date"], int))
         self.assertEqual(len(data["events"]), 1)
         self.assertEqual(data["events"][0]["type"], "sample-event")
 

--- a/test/api/test_bucketing_client.py
+++ b/test/api/test_bucketing_client.py
@@ -28,6 +28,10 @@ class BucketingClientTest(unittest.TestCase):
         self.test_client = BucketingAPIClient(sdk_key, options)
         self.test_user = DevCycleUser(user_id="test_user_id")
 
+    def test_url(self):
+        result = self.test_client._url("variable", "ABC")
+        self.assertEqual(result, "https://bucketing-api.devcycle.com/v1/variable/ABC")
+
     @responses.activate
     def test_variable(self):
         responses.add(

--- a/test/api/test_config_client.py
+++ b/test/api/test_config_client.py
@@ -1,7 +1,6 @@
 import logging
 import unittest
 import uuid
-from os.path import join
 from http import HTTPStatus
 
 import requests
@@ -15,6 +14,7 @@ from devcycle_python_sdk.exceptions import (
     APIClientUnauthorizedError,
     NotFoundError,
 )
+from devcycle_python_sdk.util.strings import slash_join
 from test.fixture.data import small_config_json
 
 logger = logging.getLogger(__name__)
@@ -24,7 +24,7 @@ class ConfigAPIClientTest(unittest.TestCase):
     def setUp(self) -> None:
         self.sdk_key = "dvc_server_" + str(uuid.uuid4())
         self.config_url = (
-            join(
+            slash_join(
                 "https://config-cdn.devcycle.com/",
                 "config",
                 "v1",
@@ -38,6 +38,9 @@ class ConfigAPIClientTest(unittest.TestCase):
         self.test_client = ConfigAPIClient(self.sdk_key, options)
         self.test_etag = str(uuid.uuid4())
         self.test_config_json: dict = small_config_json()
+
+    def test_url(self):
+        self.assertEqual(self.test_client.config_file_url, self.config_url)
 
     @responses.activate
     def test_get_config(self):

--- a/test/api/test_event_client.py
+++ b/test/api/test_event_client.py
@@ -42,6 +42,9 @@ class EventAPIClientTest(unittest.TestCase):
         ]
         self.test_batch = [UserEventsBatchRecord(user=self.test_user, events=events)]
 
+    def test_url(self):
+        self.assertEqual(self.test_client.batch_url, self.test_batch_url)
+
     @responses.activate
     def test_publish_events(self):
         responses.add(

--- a/test/fixture/data.py
+++ b/test/fixture/data.py
@@ -6,7 +6,7 @@ def small_config() -> str:
     config_filename = os.path.join(
         os.path.dirname(__file__), "fixture_small_config.json"
     )
-    with open(config_filename, "r") as f:
+    with open(config_filename, "r", encoding="utf-8") as f:
         return f.read()
 
 
@@ -19,7 +19,7 @@ def special_character_config() -> str:
     config_filename = os.path.join(
         os.path.dirname(__file__), "fixture_small_config_special_characters.json"
     )
-    with open(config_filename, "r") as f:
+    with open(config_filename, "r", encoding="utf-8") as f:
         return f.read()
 
 
@@ -32,7 +32,7 @@ def large_config() -> str:
     config_filename = os.path.join(
         os.path.dirname(__file__), "fixture_large_config.json"
     )
-    with open(config_filename, "r") as f:
+    with open(config_filename, "r", encoding="utf-8") as f:
         return f.read()
 
 
@@ -45,7 +45,7 @@ def bucketed_config() -> str:
     config_filename = os.path.join(
         os.path.dirname(__file__), "fixture_bucketed_config.json"
     )
-    with open(config_filename, "r") as f:
+    with open(config_filename, "r", encoding="utf-8") as f:
         return f.read()
 
 
@@ -53,5 +53,5 @@ def bucketed_config_minimal() -> str:
     config_filename = os.path.join(
         os.path.dirname(__file__), "fixture_bucketed_config_minimal.json"
     )
-    with open(config_filename, "r") as f:
+    with open(config_filename, "r", encoding="utf-8") as f:
         return f.read()

--- a/test/util/test_strings.py
+++ b/test/util/test_strings.py
@@ -1,0 +1,25 @@
+import logging
+
+import unittest
+
+from devcycle_python_sdk.util.strings import  slash_join
+
+logger = logging.getLogger(__name__)
+
+
+class StringsUtilTest(unittest.TestCase):
+    def test_slash_join_no_args(self):
+        result = slash_join()
+        self.assertEqual(result, "")
+
+    def test_slash_join_url_no_slashes(self):
+        result = slash_join("http://example.com", "hello", "world")
+        self.assertEqual(result, "http://example.com/hello/world")
+
+    def test_slash_join_url_components_with_slashes(self):
+        result = slash_join("http://example.com", "/hello", "world/")
+        self.assertEqual(result, "http://example.com/hello/world")
+
+    def test_slash_join_url_components_with_numbers(self):
+        result = slash_join("http://example.com", "v1", "variable", 1234)
+        self.assertEqual(result, "http://example.com/v1/variable/1234")

--- a/test/util/test_strings.py
+++ b/test/util/test_strings.py
@@ -2,7 +2,7 @@ import logging
 
 import unittest
 
-from devcycle_python_sdk.util.strings import  slash_join
+from devcycle_python_sdk.util.strings import slash_join
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
See https://github.com/DevCycleHQ/python-server-sdk/pull/57 for original report

Fixed an issue where on on windows systems the API paths would get backslash characters incorporated into them due to a misuse of the `os.paths.join` function.  

This PR fixes all those references, adds new unit tests and now runs the unit tests on Windows as well as Ubuntu