### PR TITLE
chore: update dependencies to install newer minor versions of request

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 setuptools >= 21.0.0
 urllib3 >= 1.15.1
-requests ~= 2.31.0
-wasmtime==9.0.0
+requests ~= 2.31
+wasmtime == 9.0.0
 protobuf >= 4.23.3
-openfeature-sdk>=0.7.0
+openfeature-sdk >= 0.7.0


### PR DESCRIPTION
- improves request compatibility to `>=2.31` and `<3`
- addresses: https://github.com/DevCycleHQ/python-server-sdk/issues/68