### PR TITLE
feat: default enable SSE connections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ target/
 benchmark.json
 
 pip-wheel-metadata/
+.venv/

--- a/devcycle_python_sdk/managers/config_manager.py
+++ b/devcycle_python_sdk/managers/config_manager.py
@@ -80,7 +80,7 @@ class EnvironmentConfigManager(threading.Thread):
 
             json_config = json.dumps(self._config)
             self._local_bucketing.store_config(json_config)
-            if self._options.enable_beta_realtime_updates:
+            if not self._options.disable_realtime_updates:
                 if self._sse_manager is None:
                     self._sse_manager = SSEManager(
                         self.sse_state,

--- a/devcycle_python_sdk/options.py
+++ b/devcycle_python_sdk/options.py
@@ -66,7 +66,7 @@ class DevCycleLocalOptions:
 
         if enable_beta_realtime_updates:
             logger.warning(
-                f"DevCycle: `enable_beta_realtime_updates` is deprecated and will be removed in a future release.",
+                "DevCycle: `enable_beta_realtime_updates` is deprecated and will be removed in a future release.",
             )
 
         if self.flush_event_queue_size >= self.max_event_queue_size:

--- a/devcycle_python_sdk/options.py
+++ b/devcycle_python_sdk/options.py
@@ -46,6 +46,7 @@ class DevCycleLocalOptions:
         disable_automatic_event_logging: bool = False,
         disable_custom_event_logging: bool = False,
         enable_beta_realtime_updates: bool = False,
+        disable_realtime_updates: bool = False,
     ):
         self.events_api_uri = events_api_uri
         self.config_cdn_uri = config_cdn_uri
@@ -61,7 +62,12 @@ class DevCycleLocalOptions:
         self.on_client_initialized = on_client_initialized
         self.event_request_timeout_ms = event_request_timeout_ms
         self.event_retry_delay_ms = event_retry_delay_ms
-        self.enable_beta_realtime_updates = enable_beta_realtime_updates
+        self.disable_realtime_updates = disable_realtime_updates
+
+        if enable_beta_realtime_updates:
+            logger.warning(
+                f"DevCycle: `enable_beta_realtime_updates` is deprecated and will be removed in a future release.",
+            )
 
         if self.flush_event_queue_size >= self.max_event_queue_size:
             logger.warning(

--- a/example/local_bucketing_client_example.py
+++ b/example/local_bucketing_client_example.py
@@ -21,7 +21,7 @@ def main():
 
     # create an instance of the DevCycle Client object
     server_sdk_key = os.environ["DEVCYCLE_SERVER_SDK_KEY"]
-    options = DevCycleLocalOptions(enable_beta_realtime_updates=True)
+    options = DevCycleLocalOptions()
     client = DevCycleLocalClient(server_sdk_key, options)
 
     # Wait for DevCycle to initialize and load the configuration

--- a/test/managers/test_config_manager.py
+++ b/test/managers/test_config_manager.py
@@ -19,7 +19,7 @@ class EnvironmentConfigManagerTest(unittest.TestCase):
     def setUp(self) -> None:
         self.sdk_key = "dvc_server_" + str(uuid.uuid4())
         self.test_local_bucketing = MagicMock()
-        self.test_options = DevCycleLocalOptions(config_polling_interval_ms=500)
+        self.test_options = DevCycleLocalOptions(config_polling_interval_ms=500, disable_realtime_updates=True)
 
         now = datetime.now()
         stamp = mktime(now.timetuple())

--- a/test/managers/test_config_manager.py
+++ b/test/managers/test_config_manager.py
@@ -19,7 +19,9 @@ class EnvironmentConfigManagerTest(unittest.TestCase):
     def setUp(self) -> None:
         self.sdk_key = "dvc_server_" + str(uuid.uuid4())
         self.test_local_bucketing = MagicMock()
-        self.test_options = DevCycleLocalOptions(config_polling_interval_ms=500, disable_realtime_updates=True)
+        self.test_options = DevCycleLocalOptions(
+            config_polling_interval_ms=500, disable_realtime_updates=True
+        )
 
         now = datetime.now()
         stamp = mktime(now.timetuple())

--- a/test/test_local_client.py
+++ b/test/test_local_client.py
@@ -40,7 +40,7 @@ class DevCycleLocalClientTest(unittest.TestCase):
             config_cdn_uri="http://localhost/",
             disable_custom_event_logging=True,
             disable_automatic_event_logging=True,
-            disable_realtime_updates=True
+            disable_realtime_updates=True,
         )
         self.test_user = DevCycleUser(user_id="test_user_id")
         self.test_user_empty_id = DevCycleUser(user_id="")

--- a/test/test_local_client.py
+++ b/test/test_local_client.py
@@ -40,6 +40,7 @@ class DevCycleLocalClientTest(unittest.TestCase):
             config_cdn_uri="http://localhost/",
             disable_custom_event_logging=True,
             disable_automatic_event_logging=True,
+            disable_realtime_updates=True
         )
         self.test_user = DevCycleUser(user_id="test_user_id")
         self.test_user_empty_id = DevCycleUser(user_id="")


### PR DESCRIPTION
- Enable SSE connections by default, add `disable_realtime_updates` option
- depricate `enable_beta_realtime_updates` option

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
