### PR TITLE
fix: remove dataclasses from requirements.txt as we only support python 3.8+, update setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The DevCycle Python SDK used for feature management.
 
 This SDK allows your application to interface with the [DevCycle Bucketing API](https://docs.devcycle.com/bucketing-api/#tag/devcycle).
 
-## Requirements.
+## Requirements
 
 * Python 3.8+
 
@@ -13,6 +13,7 @@ This SDK allows your application to interface with the [DevCycle Bucketing API](
 ```sh
 pip install devcycle-python-server-sdk
 ```
+
 (you may need to run `pip` with root permission: `sudo pip install devcycle-python-server-sdk`)
 
 ## Getting Started
@@ -65,38 +66,47 @@ When developing the SDK it is recommended that you have both a 3.8 and 3.12 pyth
 ### Dependencies
 
 To set up dependencies for local development, run:
-```
+
+```bash
 pip install -r requirements.test.txt
 ```
 
 To run the example app against the local version of the API for testing and development, run:
-```sh
+
+```bash
 pip install --editable .
 ```
-from the top level of the repo (same level as setup.py). Then run the example app as normal.
 
+from the top level of the repo (same level as setup.py). Then run the example app as normal:
+
+```bash
+python example/local_bucketing_client_example.py
+```
 
 ### Linting & Formatting
 
 Linting checks on PRs are run using [ruff](https://github.com/charliermarsh/ruff), and are configured using `.ruff.toml`. To run the linter locally, run this command from the top level of the repo:
-```
+
+```bash
 ruff check .
 ```
 
 Ruff can automatically fix simple linting errors (the ones marked with `[*]`). To do so, run:
-```
+
+```bash
 ruff check . --fix
 ```
 
 Formatting checks on PRs are done using [black](https://github.com/psf/black). To run the formatter locally, run this command from the top level of the repo:
 
-```
+```bash
 black .
 ```
 
 ### Unit Tests
 
 To run the unit tests, run:
+
 ```bash
 pytest
 ```
@@ -104,6 +114,7 @@ pytest
 ### Benchmarks
 
 To run the benchmarks, run:
+
 ```bash
 pytest --benchmark-only
 ```

--- a/example/local_bucketing_client_example.py
+++ b/example/local_bucketing_client_example.py
@@ -18,14 +18,11 @@ def main():
     For a Django specific sample app, please see https://github.com/DevCycleHQ/python-django-example-app/
     """
     logging.basicConfig(level="INFO", format="%(levelname)s: %(message)s")
-    logger.info("Starting DevCycle client initialization...")
 
     # create an instance of the DevCycle Client object
     server_sdk_key = os.environ["DEVCYCLE_SERVER_SDK_KEY"]
-    logger.info("Creating DevCycle client with key: %s", server_sdk_key)
     options = DevCycleLocalOptions()
     client = DevCycleLocalClient(server_sdk_key, options)
-    logger.info("Got DevCycle client")
 
     # Wait for DevCycle to initialize and load the configuration
     for i in range(10):
@@ -37,7 +34,6 @@ def main():
         logger.error("DevCycle failed to initialize")
         exit(1)
 
-    logger.info("DevCycle initialized, setting up user")
     user = DevCycleUser(user_id="test-1234", email="test-user@domain.com", country="US")
 
     # Use variable_value to access the value of a variable directly

--- a/example/local_bucketing_client_example.py
+++ b/example/local_bucketing_client_example.py
@@ -27,7 +27,7 @@ def main():
     client = DevCycleLocalClient(server_sdk_key, options)
     logger.info("Got DevCycle client")
 
-# Wait for DevCycle to initialize and load the configuration
+    # Wait for DevCycle to initialize and load the configuration
     for i in range(10):
         if client.is_initialized():
             break

--- a/example/local_bucketing_client_example.py
+++ b/example/local_bucketing_client_example.py
@@ -18,13 +18,16 @@ def main():
     For a Django specific sample app, please see https://github.com/DevCycleHQ/python-django-example-app/
     """
     logging.basicConfig(level="INFO", format="%(levelname)s: %(message)s")
+    logger.info("Starting DevCycle client initialization...")
 
     # create an instance of the DevCycle Client object
     server_sdk_key = os.environ["DEVCYCLE_SERVER_SDK_KEY"]
+    logger.info("Creating DevCycle client with key: %s", server_sdk_key)
     options = DevCycleLocalOptions()
     client = DevCycleLocalClient(server_sdk_key, options)
+    logger.info("Got DevCycle client")
 
-    # Wait for DevCycle to initialize and load the configuration
+# Wait for DevCycle to initialize and load the configuration
     for i in range(10):
         if client.is_initialized():
             break
@@ -34,6 +37,7 @@ def main():
         logger.error("DevCycle failed to initialize")
         exit(1)
 
+    logger.info("DevCycle initialized, setting up user")
     user = DevCycleUser(user_id="test-1234", email="test-user@domain.com", country="US")
 
     # Use variable_value to access the value of a variable directly

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ addopts = "--benchmark-skip --showlocals"
 
 # black options
 [tool.black]
-target-version = ['py37']
+target-version = ['py38']
 extend-exclude = '_pb2\.pyi?$'
 
 # mypy options
@@ -43,20 +43,17 @@ ignore_missing_imports = true
 [tool.ruff]
 # https://beta.ruff.rs/docs/rules/
 select = [
-	"F", # PyFlakes
-	"E", # pycodestyle error
-	"W", # pycodestyle warning
-	"N", # pep8-naming
-	"T20", # flake8-print
+	"F",      # PyFlakes
+	"E",      # pycodestyle error
+	"W",      # pycodestyle warning
+	"N",      # pep8-naming
+	"T20",    # flake8-print
 	"RUF100", # ensure noqa comments actually match an error
 ]
 ignore = [
 	"E501", # line too long
 ]
-exclude = [
-  "variableForUserParams_pb2.pyi"
-]
+exclude = ["variableForUserParams_pb2.pyi"]
 [tool.ruff.per-file-ignores]
 "__init__.py" = ["F401"]
 "variableForUserParams_pb2.py" = ["F821", "N999", "E712"]
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,3 @@ protobuf >= 4.23.3
 openfeature-sdk >= 0.7.0
 launchdarkly-eventsource >= 1.2.0
 responses~=0.23.1
-dataclasses~=0.6

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     url="https://github.com/devcycleHQ/python-server-sdk",
     keywords=["DevCycle"],
     install_requires=REQUIRES,
-    python_requires='>=3.8',
+    python_requires=">=3.8",
     packages=find_packages(),
     package_data={
         "": ["VERSION.txt"],

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
     url="https://github.com/devcycleHQ/python-server-sdk",
     keywords=["DevCycle"],
     install_requires=REQUIRES,
+    python_requires='>=3.8',
     packages=find_packages(),
     package_data={
         "": ["VERSION.txt"],


### PR DESCRIPTION
- Removed `dataclasses` from requirements.txt as python 3.7+ has it included
- Update `setup.py` and `pyproject.toml` to specify that we only support Python 3.8+ as defined in our README.md
- Cleanup README.md

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
