### PR TITLE
feat: Wrap read_event in exception handling

### DIFF
--- a/devcycle_python_sdk/managers/sse_manager.py
+++ b/devcycle_python_sdk/managers/sse_manager.py
@@ -43,7 +43,7 @@ class SSEManager:
                 elif isinstance(event, ld_eventsource.actions.Event):
                     handlemessage(event)
         except Exception as e:
-            logger.exception(f"DevCycle: failed to read all events: {e}")
+            logger.exception(f"DevCycle: failed to read SSE message: {e}")
 
     def update(self, config: dict):
         if self.use_new_config(config["sse"]):

--- a/devcycle_python_sdk/managers/sse_manager.py
+++ b/devcycle_python_sdk/managers/sse_manager.py
@@ -2,8 +2,11 @@ import threading
 
 import ld_eventsource
 import ld_eventsource.actions
+import logging
 import ld_eventsource.config
 from typing import Callable
+
+logger = logging.getLogger(__name__)
 
 
 class SSEManager:
@@ -31,13 +34,16 @@ class SSEManager:
         handlemessage: Callable[[ld_eventsource.actions.Event], None],
     ):
         self.client.start()
-        for event in self.client.all:
-            if isinstance(event, ld_eventsource.actions.Start):
-                handlestate(event)
-            elif isinstance(event, ld_eventsource.actions.Fault):
-                handleerror(event)
-            elif isinstance(event, ld_eventsource.actions.Event):
-                handlemessage(event)
+        try:
+            for event in self.client.all:
+                if isinstance(event, ld_eventsource.actions.Start):
+                    handlestate(event)
+                elif isinstance(event, ld_eventsource.actions.Fault):
+                    handleerror(event)
+                elif isinstance(event, ld_eventsource.actions.Event):
+                    handlemessage(event)
+        except Exception as e:
+            logger.exception(f"DevCycle: failed to read all events: {e}")
 
     def update(self, config: dict):
         if self.use_new_config(config["sse"]):


### PR DESCRIPTION
Thanks for the useful tool! We are currently seeing rare errors from the `read_events` thread, probably due to occasional network interruptions/container restarts/whatnot.
When this occurs, an uncaught exception bubbles up to the global scope and this is difficult for us to manage using conventional log/monitoring systems.

For reference we are seeing the following error:
```
Exception in thread Thread-4 (read_events):
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/threading.py", line 1045, in _bootstrap_inner
    self.run()
  File "/usr/local/lib/python3.11/threading.py", line 982, in run
    self._target(*self._args, **self._kwargs)
  File "/app/.venv/lib/python3.11/site-packages/devcycle_python_sdk/managers/sse_manager.py", line 34, in read_events
    for event in self.client.all:
  File "/app/.venv/lib/python3.11/site-packages/ld_eventsource/sse_client.py", line 217, in all
    raise error
  File "/app/.venv/lib/python3.11/site-packages/ld_eventsource/sse_client.py", line 189, in all
    for ec in reader.events_and_comments:
  File "/app/.venv/lib/python3.11/site-packages/ld_eventsource/reader.py", line 74, in events_and_comments
    for line in self._lines_source:
  File "/app/.venv/lib/python3.11/site-packages/ld_eventsource/reader.py", line 21, in lines_from
    for chunk in chunks:
  File "/app/.venv/lib/python3.11/site-packages/urllib3/response.py", line 1063, in stream
    yield from self.read_chunked(amt, decode_content=decode_content)
  File "/app/.venv/lib/python3.11/site-packages/urllib3/response.py", line 1219, in read_chunked
    self._update_chunk_length()
  File "/app/.venv/lib/python3.11/site-packages/urllib3/response.py", line 1149, in _update_chunk_length
    raise ProtocolError("Response ended prematurely") from None
urllib3.exceptions.ProtocolError: Response ended prematurely
```