### PR TITLE
chore: update actions workflow permissions

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,13 +1,16 @@
 name: Benchmark
 
-on: [ push ]
+on: [push]
+
+permissions:
+  contents: read
 
 jobs:
   benchmark:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.12" ]
+        python-version: ["3.12"]
 
     steps:
       - uses: actions/checkout@v4
@@ -15,7 +18,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          cache: 'pip'
+          cache: "pip"
       - name: Install dependencies
         run: |
           pip install --upgrade pip
@@ -25,9 +28,9 @@ jobs:
           pytest --benchmark-only --benchmark-json=benchmarks.json
       - name: Print summary
         run: |
-            echo "### Benchmark Results" >> $GITHUB_STEP_SUMMARY
-            echo "
-            Benchmark|Min (uS)|Median (uS)|Mean (uS)|Max (uS)|Iterations
-            ---|---|---|---|---|---
-            $(jq -r '.benchmarks[] | [.name,(.stats.min*1000000000 | round / 1000),(.stats.median*1000000000 | round / 1000),(.stats.mean*1000000000 | round / 1000),(.stats.max*1000000000 | round / 1000),.stats.rounds] | join("|")' benchmarks.json)
-            " >> $GITHUB_STEP_SUMMARY
+          echo "### Benchmark Results" >> $GITHUB_STEP_SUMMARY
+          echo "
+          Benchmark|Min (uS)|Median (uS)|Mean (uS)|Max (uS)|Iterations
+          ---|---|---|---|---|---
+          $(jq -r '.benchmarks[] | [.name,(.stats.min*1000000000 | round / 1000),(.stats.median*1000000000 | round / 1000),(.stats.mean*1000000000 | round / 1000),(.stats.max*1000000000 | round / 1000),.stats.rounds] | join("|")' benchmarks.json)
+          " >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,9 @@
 name: Lint
 on: pull_request
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint and Format
@@ -15,7 +18,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: 3.12
-          cache: 'pip'
+          cache: "pip"
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/run-test-harness.yml
+++ b/.github/workflows/run-test-harness.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   harness-tests:
     name: Harness Tests

--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -1,6 +1,9 @@
 name: Test Examples
 
-on: [ push ]
+on: [push]
+
+permissions:
+  contents: read
 
 jobs:
   test_examples:
@@ -8,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.12" ]
+        python-version: ["3.12"]
 
     steps:
       - uses: actions/checkout@v4
@@ -16,7 +19,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          cache: 'pip'
+          cache: "pip"
       - name: Install dependencies
         run: |
           pip install --upgrade pip

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -2,6 +2,9 @@ name: Unit Tests
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   unit_tests:
     name: Unit Tests


### PR DESCRIPTION
## Fix GitHub Actions Security Warning

### What Changed
Added explicit `permissions: contents: read` to GitHub workflows that were missing permission declarations, resolving the "Workflow does not contain permissions" security alert.

### Workflows Updated
- `unit_test.yml`
- `run-test-harness.yml` 
- `test_examples.yml`
- `lint.yml`
- `benchmark.yml`

### Why This Matters
- **Security**: Follows principle of least privilege by explicitly limiting workflow permissions
- **Compliance**: Resolves GitHub security alert #5 about missing workflow permissions
- **Best Practice**: Ensures workflows only have the minimum permissions they need to function

### No Breaking Changes
All workflows continue to function exactly as before, but now with proper security permissions.


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
