### PR TITLE
fix: set reason detail as 'Error' on 404

### DIFF
--- a/.github/workflows/run-test-harness.yml
+++ b/.github/workflows/run-test-harness.yml
@@ -16,4 +16,3 @@ jobs:
         with:
           sdks-to-test: python
           sdk-github-sha: ${{github.event.pull_request.head.sha}}
-          sdk-capabilities: '["cloud", "edgeDB", "clientCustomData","v2Config", "allVariables", "allFeatures", "evalReason", "cloudEvalReason", "eventsEvalReason"]'

--- a/devcycle_python_sdk/cloud_client.py
+++ b/devcycle_python_sdk/cloud_client.py
@@ -126,7 +126,7 @@ class DevCycleCloudClient(AbstractDevCycleClient):
             return Variable.create_default_variable(
                 key=key,
                 default_value=default_value,
-                default_reason_detail=DefaultReasonDetails.MISSING_VARIABLE,
+                default_reason_detail=DefaultReasonDetails.ERROR,
             )
         except BeforeHookError as e:
             self.eval_hooks_manager.run_error(context, e)

--- a/devcycle_python_sdk/models/eval_reason.py
+++ b/devcycle_python_sdk/models/eval_reason.py
@@ -14,7 +14,6 @@ class DefaultReasonDetails:
     MISSING_CONFIG = "Missing Config"
     USER_NOT_TARGETED = "User Not Targeted"
     TYPE_MISMATCH = "Variable Type Mismatch"
-    MISSING_VARIABLE = "Missing Variable"
     ERROR = "Error"
 
 

--- a/test/test_cloud_client.py
+++ b/test/test_cloud_client.py
@@ -99,7 +99,7 @@ class DevCycleCloudClientTest(unittest.TestCase):
         self.assertEqual(result.value, "default_value")
         self.assertTrue(result.isDefaulted)
         self.assertEqual(result.eval.reason, "DEFAULT")
-        self.assertEqual(result.eval.details, "Missing Variable")
+        self.assertEqual(result.eval.details, "Error")
 
         # other exception - return default
         mock_variable_call.reset_mock()


### PR DESCRIPTION
 404 can  be received from cloud bucketing in two cases:  when user isn't bucketed or when the variable doesn't exist. 
- Return error as detail instead of specifying missing variable.
- remove capability overrides for test-harness 