### PR TITLE
feat: add variable metadata in after and finally hooks

### DIFF
--- a/devcycle_python_sdk/api/local_bucketing.py
+++ b/devcycle_python_sdk/api/local_bucketing.py
@@ -5,7 +5,7 @@ import json
 
 from pathlib import Path
 from threading import Lock
-from typing import Any, cast, Optional, List
+from typing import Any, cast, Optional, List, Tuple
 
 import wasmtime
 from wasmtime import (
@@ -300,7 +300,7 @@ class LocalBucketing:
 
     def get_variable_for_user_protobuf(
         self, user: DevCycleUser, key: str, default_value: Any
-    ) -> Optional[Variable]:
+    ) -> Tuple[Optional[Variable], Optional[str]]:
         var_type = determine_variable_type(default_value)
         pb_variable_type = pb_utils.convert_type_enum_to_variable_type(var_type)
 
@@ -325,7 +325,7 @@ class LocalBucketing:
                 sdk_variable = pb2.SDKVariable_PB()
                 sdk_variable.ParseFromString(var_bytes)
 
-                return pb_utils.create_variable(sdk_variable, default_value)
+                return pb_utils.create_variable(sdk_variable, default_value), sdk_variable._feature.value
 
     def generate_bucketed_config(self, user: DevCycleUser) -> BucketedConfig:
         user_json = json.dumps(user.to_json())

--- a/devcycle_python_sdk/api/local_bucketing.py
+++ b/devcycle_python_sdk/api/local_bucketing.py
@@ -319,13 +319,14 @@ class LocalBucketing:
             variable_addr = self.VariableForUserProtobuf(self.wasm_store, params_addr)
 
             if variable_addr == 0:
-                return None
+                return None, None
             else:
                 var_bytes = self._read_assembly_script_byte_array(variable_addr)
                 sdk_variable = pb2.SDKVariable_PB()
                 sdk_variable.ParseFromString(var_bytes)
+                feature_id = sdk_variable._feature.value if sdk_variable._feature.value is not None else None
 
-                return pb_utils.create_variable(sdk_variable, default_value), sdk_variable._feature.value
+                return pb_utils.create_variable(sdk_variable, default_value), feature_id
 
     def generate_bucketed_config(self, user: DevCycleUser) -> BucketedConfig:
         user_json = json.dumps(user.to_json())

--- a/devcycle_python_sdk/api/local_bucketing.py
+++ b/devcycle_python_sdk/api/local_bucketing.py
@@ -324,7 +324,11 @@ class LocalBucketing:
                 var_bytes = self._read_assembly_script_byte_array(variable_addr)
                 sdk_variable = pb2.SDKVariable_PB()
                 sdk_variable.ParseFromString(var_bytes)
-                feature_id = sdk_variable._feature.value if sdk_variable._feature.value is not None else None
+                feature_id = (
+                    sdk_variable._feature.value
+                    if sdk_variable._feature.value is not None
+                    else None
+                )
 
                 return pb_utils.create_variable(sdk_variable, default_value), feature_id
 

--- a/devcycle_python_sdk/cloud_client.py
+++ b/devcycle_python_sdk/cloud_client.py
@@ -115,7 +115,7 @@ class DevCycleCloudClient(AbstractDevCycleClient):
                 before_hook_error = e
             variable = self.bucketing_api.variable(key, context.user)
             if before_hook_error is None:
-                self.eval_hooks_manager.run_after(context, variable)
+                self.eval_hooks_manager.run_after(context, variable, None)
             else:
                 raise before_hook_error
         except CloudClientUnauthorizedError as e:
@@ -140,7 +140,7 @@ class DevCycleCloudClient(AbstractDevCycleClient):
                 default_reason_detail=DefaultReasonDetails.ERROR,
             )
         finally:
-            self.eval_hooks_manager.run_finally(context, variable)
+            self.eval_hooks_manager.run_finally(context, variable, None)
 
         variable.defaultValue = default_value
 

--- a/devcycle_python_sdk/local_client.py
+++ b/devcycle_python_sdk/local_client.py
@@ -167,8 +167,10 @@ class DevCycleLocalClient(AbstractDevCycleClient):
                     context = changed_context
             except BeforeHookError as e:
                 before_hook_error = e
-            bucketed_variable, feature_id = self.local_bucketing.get_variable_for_user_protobuf(
-                user, key, default_value
+            bucketed_variable, feature_id = (
+                self.local_bucketing.get_variable_for_user_protobuf(
+                    user, key, default_value
+                )
             )
             if feature_id is not None:
                 variable_metadata = VariableMetadata(feature_id=feature_id)

--- a/devcycle_python_sdk/managers/eval_hooks_manager.py
+++ b/devcycle_python_sdk/managers/eval_hooks_manager.py
@@ -49,7 +49,12 @@ class EvalHooksManager:
                 raise BeforeHookError(f"Before hook failed: {e}", e)
         return modified_context
 
-    def run_after(self, context: HookContext, variable: Variable, variable_metadata: Optional[VariableMetadata]) -> None:
+    def run_after(
+        self,
+        context: HookContext,
+        variable: Variable,
+        variable_metadata: Optional[VariableMetadata],
+    ) -> None:
         """Run after hooks with the evaluation result"""
         for hook in self.hooks:
             try:
@@ -57,7 +62,12 @@ class EvalHooksManager:
             except Exception as e:
                 raise AfterHookError(f"After hook failed: {e}", e)
 
-    def run_finally(self, context: HookContext, variable: Optional[Variable], variable_metadata: Optional[VariableMetadata]) -> None:
+    def run_finally(
+        self,
+        context: HookContext,
+        variable: Optional[Variable],
+        variable_metadata: Optional[VariableMetadata],
+    ) -> None:
         """Run finally hooks after evaluation completes"""
         for hook in self.hooks:
             try:

--- a/devcycle_python_sdk/managers/eval_hooks_manager.py
+++ b/devcycle_python_sdk/managers/eval_hooks_manager.py
@@ -3,6 +3,7 @@ from typing import List, Optional
 from devcycle_python_sdk.models.eval_hook import EvalHook
 from devcycle_python_sdk.models.eval_hook_context import HookContext
 from devcycle_python_sdk.models.variable import Variable
+from devcycle_python_sdk.models.variable_metadata import VariableMetadata
 from devcycle_python_sdk.options import logger
 
 
@@ -48,19 +49,19 @@ class EvalHooksManager:
                 raise BeforeHookError(f"Before hook failed: {e}", e)
         return modified_context
 
-    def run_after(self, context: HookContext, variable: Variable) -> None:
+    def run_after(self, context: HookContext, variable: Variable, variable_metadata: Optional[VariableMetadata]) -> None:
         """Run after hooks with the evaluation result"""
         for hook in self.hooks:
             try:
-                hook.after(context, variable)
+                hook.after(context, variable, variable_metadata)
             except Exception as e:
                 raise AfterHookError(f"After hook failed: {e}", e)
 
-    def run_finally(self, context: HookContext, variable: Optional[Variable]) -> None:
+    def run_finally(self, context: HookContext, variable: Optional[Variable], variable_metadata: Optional[VariableMetadata]) -> None:
         """Run finally hooks after evaluation completes"""
         for hook in self.hooks:
             try:
-                hook.on_finally(context, variable)
+                hook.on_finally(context, variable, variable_metadata)
             except Exception as e:
                 logger.error(f"Error running finally hook: {e}")
 

--- a/devcycle_python_sdk/managers/event_queue_manager.py
+++ b/devcycle_python_sdk/managers/event_queue_manager.py
@@ -19,7 +19,6 @@ from devcycle_python_sdk.models.event import (
 from devcycle_python_sdk.models.user import DevCycleUser
 from devcycle_python_sdk.models.bucketed_config import BucketedConfig
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/devcycle_python_sdk/models/config_metadata.py
+++ b/devcycle_python_sdk/models/config_metadata.py
@@ -16,7 +16,9 @@ class ConfigMetadata:
             if value is not None:
                 if field_name == "project" and isinstance(value, ProjectMetadata):
                     result[field_name] = value.to_json()
-                elif field_name == "environment" and isinstance(value, EnvironmentMetadata):
+                elif field_name == "environment" and isinstance(
+                    value, EnvironmentMetadata
+                ):
                     result[field_name] = value.to_json()
                 else:
                     result[field_name] = value

--- a/devcycle_python_sdk/models/config_metadata.py
+++ b/devcycle_python_sdk/models/config_metadata.py
@@ -1,20 +1,27 @@
 from devcycle_python_sdk.models.environment_metadata import EnvironmentMetadata
 from devcycle_python_sdk.models.project_metadata import ProjectMetadata
 from typing import Dict, Any, Optional
+from dataclasses import dataclass
 import json
 
 
+@dataclass
 class ConfigMetadata:
-    def __init__(
-        self,
-        project: ProjectMetadata,
-        environment: EnvironmentMetadata,
-    ):
-        self.project = project
-        self.environment = environment
+    project: ProjectMetadata
+    environment: EnvironmentMetadata
 
-    def to_json(self) -> str:
-        return json.dumps(self, default=lambda o: o.__dict__)
+    def to_json(self):
+        result = {}
+        for field_name in self.__dataclass_fields__:
+            value = getattr(self, field_name)
+            if value is not None:
+                if field_name == "project" and isinstance(value, ProjectMetadata):
+                    result[field_name] = value.to_json()
+                elif field_name == "environment" and isinstance(value, EnvironmentMetadata):
+                    result[field_name] = value.to_json()
+                else:
+                    result[field_name] = value
+        return result
 
     @staticmethod
     def from_json(json_obj: Optional[Dict[str, Any]]) -> Optional["ConfigMetadata"]:

--- a/devcycle_python_sdk/models/config_metadata.py
+++ b/devcycle_python_sdk/models/config_metadata.py
@@ -2,7 +2,6 @@ from devcycle_python_sdk.models.environment_metadata import EnvironmentMetadata
 from devcycle_python_sdk.models.project_metadata import ProjectMetadata
 from typing import Dict, Any, Optional
 from dataclasses import dataclass
-import json
 
 
 @dataclass

--- a/devcycle_python_sdk/models/environment_metadata.py
+++ b/devcycle_python_sdk/models/environment_metadata.py
@@ -24,4 +24,3 @@ class EnvironmentMetadata:
             value = getattr(self, field_name)
             result[field_name] = value
         return result
-    

--- a/devcycle_python_sdk/models/environment_metadata.py
+++ b/devcycle_python_sdk/models/environment_metadata.py
@@ -24,3 +24,4 @@ class EnvironmentMetadata:
             value = getattr(self, field_name)
             result[field_name] = value
         return result
+    

--- a/devcycle_python_sdk/models/eval_hook.py
+++ b/devcycle_python_sdk/models/eval_hook.py
@@ -10,7 +10,9 @@ class EvalHook:
         self,
         before: Callable[[HookContext], Optional[HookContext]],
         after: Callable[[HookContext, Variable, Optional[VariableMetadata]], None],
-        on_finally: Callable[[HookContext, Optional[Variable], Optional[VariableMetadata]], None],
+        on_finally: Callable[
+            [HookContext, Optional[Variable], Optional[VariableMetadata]], None
+        ],
         error: Callable[[HookContext, Exception], None],
     ):
         self.before = before

--- a/devcycle_python_sdk/models/eval_hook.py
+++ b/devcycle_python_sdk/models/eval_hook.py
@@ -2,14 +2,15 @@ from typing import Callable, Optional
 
 from devcycle_python_sdk.models.eval_hook_context import HookContext
 from devcycle_python_sdk.models.variable import Variable
+from devcycle_python_sdk.models.variable_metadata import VariableMetadata
 
 
 class EvalHook:
     def __init__(
         self,
         before: Callable[[HookContext], Optional[HookContext]],
-        after: Callable[[HookContext, Variable], None],
-        on_finally: Callable[[HookContext, Optional[Variable]], None],
+        after: Callable[[HookContext, Variable, Optional[VariableMetadata]], None],
+        on_finally: Callable[[HookContext, Optional[Variable], Optional[VariableMetadata]], None],
         error: Callable[[HookContext, Exception], None],
     ):
         self.before = before

--- a/devcycle_python_sdk/models/eval_hook_context.py
+++ b/devcycle_python_sdk/models/eval_hook_context.py
@@ -1,18 +1,32 @@
 from typing import Any, Optional
+from dataclasses import dataclass
 
 from devcycle_python_sdk.models.user import DevCycleUser
 from devcycle_python_sdk.models.config_metadata import ConfigMetadata
 
 
+@dataclass
 class HookContext:
-    def __init__(
-        self,
-        key: str,
-        user: DevCycleUser,
-        default_value: Any,
-        config_metadata: Optional[ConfigMetadata] = None,
-    ):
-        self.key = key
-        self.default_value = default_value
-        self.user = user
-        self.config_metadata = config_metadata
+    key: str
+    user: DevCycleUser
+    default_value: Any
+    config_metadata: Optional[ConfigMetadata] = None
+
+    def to_json(self):
+        result = {}
+        for field_name in self.__dataclass_fields__:
+            value = getattr(self, field_name)
+            if value is not None:
+                if field_name == "config_metadata" and isinstance(value, ConfigMetadata):
+                    result[field_name] = value.to_json()
+                elif field_name == "user" and isinstance(value, DevCycleUser):
+                    result[field_name] = value.to_json()
+                else:
+                    result[field_name] = value
+        return result
+
+    def __str__(self):
+        return f"HookContext(key={self.key}, user={self.user}, default_value={self.default_value}, config_metadata={self.config_metadata})"
+
+    def __repr__(self):
+        return self.__str__()

--- a/devcycle_python_sdk/models/eval_hook_context.py
+++ b/devcycle_python_sdk/models/eval_hook_context.py
@@ -24,9 +24,3 @@ class HookContext:
                 else:
                     result[field_name] = value
         return result
-
-    def __str__(self):
-        return f"HookContext(key={self.key}, user={self.user}, default_value={self.default_value}, config_metadata={self.config_metadata})"
-
-    def __repr__(self):
-        return self.__str__()

--- a/devcycle_python_sdk/models/eval_hook_context.py
+++ b/devcycle_python_sdk/models/eval_hook_context.py
@@ -17,7 +17,9 @@ class HookContext:
         for field_name in self.__dataclass_fields__:
             value = getattr(self, field_name)
             if value is not None:
-                if field_name == "config_metadata" and isinstance(value, ConfigMetadata):
+                if field_name == "config_metadata" and isinstance(
+                    value, ConfigMetadata
+                ):
                     result[field_name] = value.to_json()
                 elif field_name == "user" and isinstance(value, DevCycleUser):
                     result[field_name] = value.to_json()

--- a/devcycle_python_sdk/models/project_metadata.py
+++ b/devcycle_python_sdk/models/project_metadata.py
@@ -1,14 +1,11 @@
 from typing import Dict, Any, Optional
+from dataclasses import dataclass
 
 
+@dataclass
 class ProjectMetadata:
-    def __init__(
-        self,
-        id: str,
-        key: str,
-    ):
-        self.id = id
-        self.key = key
+    id: str
+    key: str
 
     @staticmethod
     def from_json(json_obj: Optional[Dict[str, Any]]) -> Optional["ProjectMetadata"]:
@@ -18,3 +15,10 @@ class ProjectMetadata:
             id=json_obj["id"],
             key=json_obj["key"],
         )
+
+    def to_json(self):
+        result = {}
+        for field_name in self.__dataclass_fields__:
+            value = getattr(self, field_name)
+            result[field_name] = value
+        return result

--- a/devcycle_python_sdk/models/variable_metadata.py
+++ b/devcycle_python_sdk/models/variable_metadata.py
@@ -3,19 +3,15 @@ from dataclasses import dataclass
 
 
 @dataclass
-class EnvironmentMetadata:
-    id: str
-    key: str
+class VariableMetadata:
+    feature_id: str
 
     @staticmethod
-    def from_json(
-        json_obj: Optional[Dict[str, Any]],
-    ) -> Optional["EnvironmentMetadata"]:
+    def from_json(json_obj: Optional[Dict[str, Any]]) -> Optional["VariableMetadata"]:
         if json_obj is None:
             return None
-        return EnvironmentMetadata(
-            id=json_obj["id"],
-            key=json_obj["key"],
+        return VariableMetadata(
+            feature_id=json_obj["feature_id"],
         )
 
     def to_json(self):

--- a/example/django-app/requirements.txt
+++ b/example/django-app/requirements.txt
@@ -1,2 +1,2 @@
 django >= 4.2
-devcycle-python-server-sdk >= 3.0.1
+-e ../../

--- a/test/api/test_local_bucketing.py
+++ b/test/api/test_local_bucketing.py
@@ -98,7 +98,7 @@ class LocalBucketingTest(unittest.TestCase):
         self.local_bucketing.set_platform_data(platform_json)
         self.local_bucketing.init_event_queue(self.client_uuid, "{}")
         user = DevCycleUser(user_id="test_user_id")
-        result = self.local_bucketing.get_variable_for_user_protobuf(
+        result, feature_id = self.local_bucketing.get_variable_for_user_protobuf(
             user=user, key="string-var", default_value="default value"
         )
         self.assertIsNotNone(result)
@@ -106,6 +106,7 @@ class LocalBucketingTest(unittest.TestCase):
         self.assertEqual(result.type, TypeEnum.STRING)
         self.assertEqual(result.value, "variationOn")
         self.assertFalse(result.isDefaulted)
+        self.assertIsNotNone(feature_id)
 
     def test_get_variable_for_user_protobuf_special_characters(self):
         self.local_bucketing.store_config(special_character_config())
@@ -113,7 +114,7 @@ class LocalBucketingTest(unittest.TestCase):
         self.local_bucketing.set_platform_data(platform_json)
         self.local_bucketing.init_event_queue(self.client_uuid, "{}")
         user = DevCycleUser(user_id="test_user_id")
-        result = self.local_bucketing.get_variable_for_user_protobuf(
+        result, feature_id = self.local_bucketing.get_variable_for_user_protobuf(
             user=user, key="string-var", default_value="default value"
         )
         self.assertIsNotNone(result)
@@ -121,6 +122,7 @@ class LocalBucketingTest(unittest.TestCase):
         self.assertEqual(result.type, TypeEnum.STRING)
         self.assertEqual(result.value, "öé 🐍 ¥ variationOn")
         self.assertFalse(result.isDefaulted)
+        self.assertIsNotNone(feature_id)
 
     def test_get_variable_for_user_protobuf_type_mismatch(self):
         self.local_bucketing.store_config(small_config())
@@ -131,10 +133,11 @@ class LocalBucketingTest(unittest.TestCase):
 
         # type mismatch is handled inside the WASM and will return
         # no data if the type is not correct
-        result = self.local_bucketing.get_variable_for_user_protobuf(
+        result, feature_id = self.local_bucketing.get_variable_for_user_protobuf(
             user=user, key="string-var", default_value=9999
         )
         self.assertIsNone(result)
+        self.assertIsNone(feature_id)
 
     def test_generate_bucketed_config(self):
         self.local_bucketing.store_config(small_config())

--- a/test/models/test_user.py
+++ b/test/models/test_user.py
@@ -6,7 +6,6 @@ from devcycle_python_sdk.models.user import DevCycleUser
 from openfeature.provider import EvaluationContext
 from openfeature.exception import TargetingKeyMissingError, InvalidContextError
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/test/openfeature_test/test_provider.py
+++ b/test/openfeature_test/test_provider.py
@@ -21,7 +21,6 @@ from devcycle_python_sdk.open_feature_provider.provider import (
     DevCycleProvider,
 )
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/test/test_cloud_client.py
+++ b/test/test_cloud_client.py
@@ -306,10 +306,10 @@ class DevCycleCloudClientTest(unittest.TestCase):
             hook_called["before"] = True
             return context
 
-        def after_hook(context, variable):
+        def after_hook(context, variable, variable_metadata):
             hook_called["after"] = True
 
-        def finally_hook(context, variable):
+        def finally_hook(context, variable, variable_metadata):
             hook_called["finally"] = True
 
         def error_hook(context, error):
@@ -346,10 +346,10 @@ class DevCycleCloudClientTest(unittest.TestCase):
             hook_called["before"] = True
             raise Exception("Before hook failed")
 
-        def after_hook(context, variable):
+        def after_hook(context, variable, variable_metadata):
             hook_called["after"] = True
 
-        def finally_hook(context, variable):
+        def finally_hook(context, variable, variable_metadata):
             hook_called["finally"] = True
 
         def error_hook(context, error):
@@ -382,10 +382,10 @@ class DevCycleCloudClientTest(unittest.TestCase):
             context_received = context
             return context
 
-        def after_hook(context, variable):
+        def after_hook(context, variable, variable_metadata):
             pass
 
-        def finally_hook(context, variable):
+        def finally_hook(context, variable, variable_metadata):
             pass
 
         def error_hook(context, error):

--- a/test/test_cloud_client.py
+++ b/test/test_cloud_client.py
@@ -5,7 +5,6 @@ import uuid
 from time import time
 from unittest.mock import patch
 
-
 from devcycle_python_sdk import DevCycleCloudClient, DevCycleCloudOptions
 from devcycle_python_sdk.models.eval_hook import EvalHook
 from devcycle_python_sdk.models.user import DevCycleUser

--- a/test/test_local_client.py
+++ b/test/test_local_client.py
@@ -392,10 +392,10 @@ class DevCycleLocalClientTest(unittest.TestCase):
             hook_called["before"] = True
             return context
 
-        def after_hook(context, variable):
+        def after_hook(context, variable, variable_metadata):
             hook_called["after"] = True
 
-        def finally_hook(context, variable):
+        def finally_hook(context, variable, variable_metadata):
             hook_called["finally"] = True
 
         def error_hook(context, error):
@@ -435,7 +435,7 @@ class DevCycleLocalClientTest(unittest.TestCase):
         def after_hook(context, variable, variable_metadata):
             hook_called["after"] = True
 
-        def finally_hook(context, variable):
+        def finally_hook(context, variable, variable_metadata):
             hook_called["finally"] = True
 
         def error_hook(context, error):
@@ -468,10 +468,10 @@ class DevCycleLocalClientTest(unittest.TestCase):
             context_received = context
             return context
 
-        def after_hook(context, variable):
+        def after_hook(context, variable, variable_metadata):
             pass
 
-        def finally_hook(context, variable):
+        def finally_hook(context, variable, variable_metadata):
             pass
 
         def error_hook(context, error):

--- a/test/test_local_client.py
+++ b/test/test_local_client.py
@@ -432,7 +432,7 @@ class DevCycleLocalClientTest(unittest.TestCase):
             hook_called["before"] = True
             raise Exception("Before hook failed")
 
-        def after_hook(context, variable):
+        def after_hook(context, variable, variable_metadata):
             hook_called["after"] = True
 
         def finally_hook(context, variable):


### PR DESCRIPTION
- added variable metadata 
- updated metadata and context fields to be a dataclass and json outputs
- update django app to use the local version of the sdk
- tset using the django app and hooks

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
