### PR TITLE
fix: initialize payloads before try block in _flush_events

### DIFF
--- a/devcycle_python_sdk/managers/event_queue_manager.py
+++ b/devcycle_python_sdk/managers/event_queue_manager.py
@@ -88,6 +88,7 @@ class EventQueueManager(threading.Thread):
             return 0
 
         with self._flush_lock:
+            payloads = []
             try:
                 payloads = self._local_bucketing.flush_event_queue()
             except Exception as e:

--- a/test/managers/test_event_queue_manager.py
+++ b/test/managers/test_event_queue_manager.py
@@ -148,6 +148,24 @@ class EventQueueManagerTest(unittest.TestCase):
         self.test_local_bucketing.on_event_payload_success.assert_not_called()
 
     @patch("devcycle_python_sdk.api.event_client.EventAPIClient.publish_events")
+    def test_flush_events_wasm_error_does_not_raise(self, mock_publish_events):
+        self.test_local_bucketing.flush_event_queue.side_effect = Exception(
+            "WASMAbortError: Request Payload has not finished sending"
+        )
+
+        manager = EventQueueManager(
+            self.sdk_key,
+            self.client_uuid,
+            self.test_options_no_thread,
+            self.test_local_bucketing,
+        )
+        # Must not raise UnboundLocalError; must return 0
+        result = manager._flush_events()
+
+        self.assertEqual(result, 0)
+        mock_publish_events.assert_not_called()
+
+    @patch("devcycle_python_sdk.api.event_client.EventAPIClient.publish_events")
     def test_flush_events_no_events(self, mock_publish_events):
         self.test_local_bucketing.flush_event_queue = MagicMock()
         self.test_local_bucketing.flush_event_queue.return_value = []


### PR DESCRIPTION
## Summary

- Initializes `payloads = []` before the `try` block in `_flush_events` so a `flush_event_queue()` exception (e.g. a WASM trap) no longer causes `UnboundLocalError: local variable 'payloads' referenced before assignment` on the subsequent `if payloads:` check
- Adds a regression test covering this path

## Related Issues

Fixes #111