### PR TITLE
fix: broaden openfeature-sdk constraint to allow 0.9.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ urllib3 >= 1.15.1
 requests >= 2.33.0
 wasmtime ~= 30.0.0
 protobuf >= 4.23.3
-openfeature-sdk ~= 0.8.0
+openfeature-sdk ~= 0.8
 launchdarkly-eventsource >= 1.2.1
 responses >= 0.23.1


### PR DESCRIPTION
Fixes #113

Changes `openfeature-sdk ~= 0.8.0` to `~= 0.8` in `requirements.txt`, which allows 0.8.x and 0.9.x (and any future 0.x minor). The DevCycle provider code is compatible with 0.9.0: no imports from the removed `openfeature.provider.provider` module, and we already require Python 3.10+.