### PR TITLE
build: stop pulling setuptools into runtime dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools>=21.0.0"]
+build-backend = "setuptools.build_meta"
+
 # pytest options
 [tool.pytest.ini_options]
 minversion = "9.0"

--- a/requirements.lint.txt
+++ b/requirements.lint.txt
@@ -3,6 +3,7 @@
 black~=26.3.1
 mypy~=1.15.0
 mypy-extensions~=1.0.0
+responses~=0.25.6
 ruff~=0.9.0
 types-requests~=2.33.0
 types-urllib3~=1.26.25.14

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-setuptools >= 21.0.0
 urllib3 >= 1.15.1
 requests >= 2.33.0
 wasmtime ~= 30.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ wasmtime ~= 30.0.0
 protobuf >= 4.23.3
 openfeature-sdk ~= 0.8
 launchdarkly-eventsource >= 1.2.1
-responses >= 0.23.1


### PR DESCRIPTION
`setuptools` was listed in `requirements.txt` and thus propagated to `install_requires`, forcing it as a runtime dependency for downstream installs even though it is never imported at runtime.

Remove it from requirements.txt and instead declare it as a build-time requirement only.

Update: also removed `responses` from `requirements.txt` which is already declared in `requirements.test.txt`